### PR TITLE
feat: improve import handling for partials starting with _ prefix

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -13,8 +13,11 @@ function convert(logger, projectDir, options) {
     var sassImportPath = path.join(projectDir, 'app/');
     console.log("SASS Import Path", sassImportPath);
     
-		var sassFiles = glob.sync(sassFilesPath).filter(function(fileName){
-			return fileName.indexOf("App_Resources") === -1;
+		var sassFiles = glob.sync(sassFilesPath).filter(function(filePath){
+			var path = filePath;
+      var parts = path.split('/');
+      var filename = parts[parts.length - 1];
+			return path.indexOf("App_Resources") === -1 && filename.indexOf("_") !== 0;
 		});
     
     if(sassFiles.length === 0){


### PR DESCRIPTION
@toddanglin Love this plugin. This will make the import handling much better and standardized when handling partial imports. Standard is using `_` prefixed files so given a sass structure like the following will work as expected:

```
app.scss
scss/
  _buttons.scss
  _variables.scss
```

where `app.scss` may look like this:

```
import 'scss/variables';
import 'scss/buttons';
```

And it will work without error since it will only actually compile `app.scss` to `app.css` and not compile 1-1 compiles for the partials which would cause an error with the other imports. 👍 

After merging, please bump, and release! Thanks for great plugin.
