### PR TITLE
Ability to import SCSS files from node modules

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -10,8 +10,11 @@ function convert(logger, projectDir, options) {
 		options = options || {};
 		
 		var sassFilesPath = path.join(projectDir, 'app/**/*.scss');
-    var sassImportPath = path.join(projectDir, 'app/');
-    //console.log("SASS Import Path", sassImportPath);
+    var sassImportPaths = [
+      path.join(projectDir, 'app/'), 
+      path.join(projectDir, 'node_modules/')
+      ];
+    //console.log("SASS Import Path", sassImportPaths);
     
 		var sassFiles = glob.sync(sassFilesPath).filter(function(filePath){
 			var path = filePath;
@@ -26,7 +29,7 @@ function convert(logger, projectDir, options) {
     } else {      
       var i = 0;
       var loopSassFilesAsync = function(sassFiles){
-        parseSass(sassFiles[i], sassImportPath, function(e){
+        parseSass(sassFiles[i], sassImportPaths, function(e){
           if(e !== undefined){
             //Error in the LESS parser; Reject promise
             reject(Error(sassFiles[i] + ' SASS CSS pre-processing failed. Error: ' + e));  
@@ -48,13 +51,13 @@ function convert(logger, projectDir, options) {
 	});
 }
 
-function parseSass(filePath, importPath, callback){
+function parseSass(filePath, importPaths, callback){
   var sassFileContent = fs.readFileSync(filePath, { encoding: 'utf8'});
   var cssFilePath = filePath.replace('.scss', '.css');
   
   sass.render({
     data: sassFileContent,
-    includePaths: [importPath],
+    includePaths: importPaths,
     outFile: cssFilePath,
     outputStyle: 'compressed'
   }, function (e, output) {


### PR DESCRIPTION
With this PR you will be able to import `scss` files form node_modules.

For example if create a npm module `my-nativescript-themes` that has a `/scss/_light.scss` file, 
I can import it with:

```
@import 'my-nativescript-themes/scss/light';
```
