### PR TITLE
fix: #10 bug: Throws an error if scss-file is empty

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -54,7 +54,15 @@ function convert(logger, projectDir, options) {
 function parseSass(filePath, importPaths, callback){
   var sassFileContent = fs.readFileSync(filePath, { encoding: 'utf8'});
   var cssFilePath = filePath.replace('.scss', '.css');
-  
+
+  if(sassFileContent.trim().length === 0) {
+    // No SASS content write an empty file
+    fs.writeFile(cssFilePath, '', 'utf8', function(){
+      callback();
+    });
+    return;
+  }
+
   sass.render({
     data: sassFileContent,
     includePaths: importPaths,
@@ -66,14 +74,15 @@ function parseSass(filePath, importPaths, callback){
       callback(e);
     }      
     
-    if(output === null){
-      //No CSS content in converted scss file; No need to write file
-      callback();
+    if(output && output.css){
+      output = output.css;
     } else {
-      fs.writeFile(cssFilePath, output.css, 'utf8', function(){
-        //File done writing
-        callback();
-      });  
-    }                                                  
+      output = '';
+    }
+
+    fs.writeFile(cssFilePath, output, 'utf8', function(){
+      //File done writing
+      callback();
+    });
   });
 }


### PR DESCRIPTION
- Will no longer throw an error for empty files
- nativescript-angular: ng2 throws errors if css-files doesn't exist, to accommodate that write empty css-files if the sass-file is empty
