### PR TITLE
Fix for path resolution

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -6,38 +6,40 @@ var sass = require('node-sass');
 var glob = require('glob');
 
 function convert(logger, projectDir, options) {
-	return new Promise(function (resolve, reject) {
-		options = options || {};
-		
-		var sassFilesPath = path.join(projectDir, 'app/**/*.scss');
+  return new Promise(function (resolve, reject) {
+    options = options || {};
+
+    var sassFilesPath = path.join(projectDir, 'app/**/*.scss');
     var sassImportPaths = [
-      path.join(projectDir, 'app/'), 
+      path.join(projectDir, 'app/'),
       path.join(projectDir, 'node_modules/')
-      ];
+    ];
     //console.log("SASS Import Path", sassImportPaths);
-    
-		var sassFiles = glob.sync(sassFilesPath, { follow: true }).filter(function(filePath){
-			var path = filePath;
-      var parts = path.split('/');
+
+    var sassFiles = glob.sync(sassFilesPath, {follow: true}).filter(function (filePath) {
+      if (!(sassImportPaths.find(function (element) {return path.dirname(filePath) === element}))) {
+        sassImportPaths.push(path.dirname(filePath));
+      }
+      var parts = filePath.split('/');
       var filename = parts[parts.length - 1];
-			return path.indexOf("App_Resources") === -1 && filename.indexOf("_") !== 0;
-		});
-    
-    if(sassFiles.length === 0){
+      return filePath.indexOf("App_Resources") === -1 && filename.indexOf("_") !== 0;
+    });
+
+    if (sassFiles.length === 0) {
       //No sass files in project; skip parsing
       resolve();
-    } else {      
+    } else {
       var i = 0;
-      var loopSassFilesAsync = function(sassFiles){
-        parseSass(sassFiles[i], sassImportPaths, function(e){
-          if(e !== undefined){
+      var loopSassFilesAsync = function (sassFiles) {
+        parseSass(sassFiles[i], sassImportPaths, function (e) {
+          if (e !== undefined) {
             //Error in the LESS parser; Reject promise
-            reject(Error(sassFiles[i] + ' SASS CSS pre-processing failed. Error: ' + e));  
+            reject(Error(sassFiles[i] + ' SASS CSS pre-processing failed. Error: ' + e));
           }
-          
+
           i++; //Increment loop counter
-          
-          if(i < sassFiles.length){
+
+          if (i < sassFiles.length) {
             loopSassFilesAsync(sassFiles);
           } else {
             //All files have been processed; Resolve promise
@@ -45,19 +47,19 @@ function convert(logger, projectDir, options) {
           }
         });
       }
-      
+
       loopSassFilesAsync(sassFiles);
     }
-	});
+  });
 }
 
-function parseSass(filePath, importPaths, callback){
-  var sassFileContent = fs.readFileSync(filePath, { encoding: 'utf8'});
+function parseSass(filePath, importPaths, callback) {
+  var sassFileContent = fs.readFileSync(filePath, {encoding: 'utf8'});
   var cssFilePath = filePath.replace('.scss', '.css');
 
-  if(sassFileContent.trim().length === 0) {
+  if (sassFileContent.trim().length === 0) {
     // No SASS content write an empty file
-    fs.writeFile(cssFilePath, '', 'utf8', function(){
+    fs.writeFile(cssFilePath, '', 'utf8', function () {
       callback();
     });
     return;
@@ -69,18 +71,18 @@ function parseSass(filePath, importPaths, callback){
     outFile: cssFilePath,
     outputStyle: 'compressed'
   }, function (e, output) {
-    if(e) {
+    if (e) {
       //Callback with error
       callback(e);
-    }      
-    
-    if(output && output.css){
+    }
+
+    if (output && output.css) {
       output = output.css;
     } else {
       output = '';
     }
 
-    fs.writeFile(cssFilePath, output, 'utf8', function(){
+    fs.writeFile(cssFilePath, output, 'utf8', function () {
       //File done writing
       callback();
     });


### PR DESCRIPTION
Currently a _*.scss file could not be found and imported unless it was in the app/ directory or it had been found before the importing file (and the importing file would need to reference it as just it’s name and couldn’t include actual path info which would then throw off the code completion of the IDE).

This change adds to the sassImportPaths as it globs the sassFiles if that files path is not yet present in the sassImportPaths.

This allows for a more flexible file structure.