### PR TITLE
fix: Issue #34 when `tns prepare` is called with --path option

### DIFF
--- a/lib/importer.js
+++ b/lib/importer.js
@@ -3,7 +3,7 @@ var path = require("path");
 module.exports = function(url, prev, done) {
   if (url[0] === '~' && url[1] !== '/') {
     // Resolve "~" paths to node_modules
-    url = path.resolve('node_modules', url.substr(1));
+    url = path.resolve(__dirname, "../../../node_modules", url.substr(1));
   } else if (url[0] === '~' && url[1] === '/') {
     // Resolve "~/" paths to the app root
     url = path.resolve(__dirname, "../../../app/"+ url.substr(2));


### PR DESCRIPTION
Handle the case when `tns prepare` is called outside of the NativeScript project but with --path option.