### PR TITLE
Use the after-watch hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
         "type": "before-watch",
         "script": "lib/watch.js",
         "inject": true
+      },
+      {
+        "type": "after-watch",
+        "script": "lib/after-watch.js",
+        "inject": true
       }
     ],
     "tns-ios": {


### PR DESCRIPTION
Use the after-watch hook, which is raised when LiveSync operation stops and kill currently running node-sass compiler.  - This change was missed out in https://github.com/NativeScript/nativescript-dev-sass/pull/40, which is copy of https://github.com/NativeScript/nativescript-dev-typescript/pull/34/