### PR TITLE
Update node-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.6",
-    "node-sass": "*",
+    "node-sass": "4.5.3",
     "glob": "*",
     "nativescript-hook": "^0.2.0"
   },


### PR DESCRIPTION
There is an issue with watchers in the latest version of node-sass.  This fixes us to to the last version that worked.  Fixes issue https://github.com/NativeScript/nativescript-dev-sass/issues/47