### PR TITLE
Update to node-sass version with fixed watchers

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.6",
-    "node-sass": "^4.6.1",
+    "node-sass": "^4.7.1",
     "glob": "^7.1.2",
     "nativescript-hook": "^0.2.0"
   },


### PR DESCRIPTION
I verified that 4.7.1 has it's watchers fixed, and some other benefits: https://github.com/sass/node-sass/releases/tag/v4.7.1