### PR TITLE
Use node-sass-chokidar instead of node-sass

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -10,17 +10,17 @@ function convert(logger, projectDir, options) {
     return new Promise(function (resolve, reject) {
         options = options || {};
 
-        var peerSassPath = path.join(__dirname, '../../node-sass');
-        var sassPath = path.join(peerSassPath, 'bin/node-sass');
+        var peerSassPath = path.join(__dirname, '../../node-sass-chokidar');
+        var sassPath = path.join(peerSassPath, 'bin/node-sass-chokidar');
         var appDir = path.join(projectDir, "app");
         var importerPath = path.join(__dirname, "importer.js");
 
         if (fs.existsSync(sassPath)) {
             try {
-                logger.info('Found peer node-sass');
+                logger.info('Found peer node-sass-chokidar');
             } catch (err) { }
         } else {
-            throw Error('node-sass installation local to project was not found. Install by executing `npm install node-sass`.');
+            throw Error('node-sass-chokidar installation local to project was not found. Install by executing `npm install node-sass-chokidar`.');
         }
 
         // Node SASS Command Line Args (https://github.com/sass/node-sass#command-line-interface)
@@ -30,9 +30,9 @@ function convert(logger, projectDir, options) {
         // --follow : Follow symlinked directories
         // -r : Recursively watch directories or files
         // --watch : Watch a directory or file
-        var nodeArgs = [sassPath, appDir, '--output', appDir, '--output-style', 'compressed', '-q', '--follow', '--importer', importerPath];
+        var nodeArgs = [sassPath, appDir, '-o', appDir, '--output-style', 'compressed', '-q', '--follow', '--importer', importerPath];
         if (options.watch) {
-            nodeArgs.push('-r', '--watch');
+            nodeArgs.push('--recursive', '--watch');
         }
 
         logger.trace(process.execPath, nodeArgs.join(' '));

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.6",
-    "node-sass": "^4.7.1",
+    "node-sass-chokidar": "^0.0.3",    
     "glob": "^7.1.2",
     "nativescript-hook": "^0.2.0"
   },


### PR DESCRIPTION
Change includes use of node-sass-chokidar(node-sass wrapper) instead of direct use of node-sass  to fix infinite SASS compiling issue: https://github.com/NativeScript/nativescript-dev-sass/issues/53