### PR TITLE
feat(watch): use before-watchPatterns hook

### DIFF
--- a/lib/before-watchPatterns.js
+++ b/lib/before-watchPatterns.js
@@ -1,0 +1,11 @@
+module.exports = function (hookArgs) {
+	if (hookArgs.liveSyncData && !hookArgs.liveSyncData.bundle) {
+		return (args, originalMethod) => {
+			return originalMethod().then(originalPatterns => {
+				originalPatterns.push("!app/**/*.scss");
+
+				return originalPatterns;
+			});
+		};
+	}
+}

--- a/src/lib/watch.js
+++ b/src/lib/watch.js
@@ -1,5 +1,13 @@
 var converter = require('./converter');
 
-module.exports = function (logger, projectData, usbLiveSyncService) {
+module.exports = function (logger, projectData, usbLiveSyncService, hookArgs) {
+	if (hookArgs.config) {
+		const appFilesUpdaterOptions = hookArgs.config.appFilesUpdaterOptions;
+		if (appFilesUpdaterOptions.bundle) {
+			logger.warn("Hook skipped because bundling is in progress.")
+			return;
+		}
+	}
+
 	return converter.convert(logger, projectData.projectDir, { watch: true });
 }

--- a/src/package.json
+++ b/src/package.json
@@ -23,6 +23,11 @@
         "inject": true
       },
       {
+        "type": "before-watchPatterns",
+        "script": "lib/before-watchPatterns.js",
+        "inject": true
+      },
+      {
         "type": "after-prepare",
         "script": "lib/after-prepare.js",
         "inject": true


### PR DESCRIPTION
Use CLI's `before-watchPatterns` hook in order to instruct CLI not to watch `.scss` files.
In addition do not launch a `sass` watch process when bundling, assume bundler will handle it.

Ping @rosen-vladimirov

Merge after https://github.com/NativeScript/nativescript-cli/pull/3350