### PR TITLE
Don't stop livesync process when sass compilation error occurs

### DIFF
--- a/src/lib/converter.js
+++ b/src/lib/converter.js
@@ -44,7 +44,15 @@ function createWatcher(data) {
 	
 	watcher = choki.watch(['**/*.scss', '**/*.sass'], watcherOptions)
 		.on('all', (event, filePath) => {
-			watchPromisesChain = watchPromisesChain.then(() => spawnNodeSass(data));
+			watchPromisesChain = watchPromisesChain
+				.then(() => spawnNodeSass(data))
+				.catch(err => {
+					if (err.stopExecution === false && err.errorAsWarning) {
+						data.logger.warn(err.message);
+					} else {
+						throw err;
+					}
+				});
 		});
 }
 
@@ -110,6 +118,8 @@ function spawnNodeSass(data) {
 			logger.info(err.message);
 			if (!isResolved) {
 				isResolved = true;
+				err.errorAsWarning = true;
+				err.stopExecution = false;
 				reject(err);
 			}
 		});
@@ -122,7 +132,10 @@ function spawnNodeSass(data) {
 				if (code === 0) {
 					resolve();
 				} else {
-					reject(new Error('SASS compiler failed with exit code ' + code));
+					var error = new Error('SASS compiler failed with exit code ' + code);
+					error.errorAsWarning = true;
+					error.stopExecution = false;
+					reject(error);
 				}
 			}
 		});

--- a/src/lib/converter.js
+++ b/src/lib/converter.js
@@ -47,7 +47,7 @@ function createWatcher(data) {
 			watchPromisesChain = watchPromisesChain
 				.then(() => spawnNodeSass(data))
 				.catch(err => {
-					if (err.stopExecution === false && err.errorAsWarning) {
+					if (!err.stopExecution && err.errorAsWarning) {
 						data.logger.warn(err.message);
 					} else {
 						throw err;


### PR DESCRIPTION
Do not exit livesync process when some compilation error occurs.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
When `tns run` command is executed and the user makes some compilation error, {N} CLI process exits.

## What is the new behavior?
When `tns run` command is executed and the user makes some compilation error, {N} CLI prints an error as a warning and process does not exit.

