### PR TITLE
Add ignoreInitial back to watcher options and fix initial transpilation

### DIFF
--- a/src/lib/converter.js
+++ b/src/lib/converter.js
@@ -17,8 +17,7 @@ function convert(logger, projectDir, appDir, appResourcesDir, options) {
 	};
 	
 	if (options.watch) {
-		createWatcher(data);
-		return;
+		return createWatcher(data);
 	}
 
 	return sassCompiler.compile(data);
@@ -40,6 +39,8 @@ function createWatcher(data) {
 			data.logger[message.logLevel](message.message);
 		}
 	});
+
+	return sassCompiler.compile(data);
 }
 
 function dispose() {

--- a/src/lib/watcher.js
+++ b/src/lib/watcher.js
@@ -10,6 +10,7 @@ var appResourcesDir = args.appResourcesDir;
 var watchPromisesChain = Promise.resolve();
 
 var watcherOptions = {
+    ignoreInitial: true,
     cwd: appDir,
     awaitWriteFinish: {
         pollInterval: 100,


### PR DESCRIPTION
Currently sometimes files produced from compilation are not uploaded to device because {N} CLI does not await the compilation to finish. Returns a promise from before-watch hook, so {N} CLI is able to await the initial compilation and upload all produced files to device. 
Also returns back `ignoreInitial` option to wacherOptions.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included


