### PR TITLE
fix: disregard false matches from chokidar

### DIFF
--- a/src/lib/watcher.js
+++ b/src/lib/watcher.js
@@ -21,6 +21,11 @@ var watcherOptions = {
 
 watcher = choki.watch('**/*.s[ac]ss', watcherOptions)
     .on('all', (event, filePath) => {
+        // Workaround for false matches from chokidar
+        if (!filePath.match(/\.s[ac]ss$/i)) {
+            return;
+        }
+
         watchPromisesChain = watchPromisesChain
             .then(() => compiler.compile({appDir, projectDir}))
             .catch(err => {


### PR DESCRIPTION
Chokidar is firing events for files that don't match the glob when
those files are under symlinked directories. Check that the path
actually matches ".s[ac]ss" before triggering a compile.

Fixes 

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
On macOS 10.14, having a symlinked directory containing SCSS files causes an infinite compilation loop when using `tns run` without `--bundle`.

## What is the new behavior?
The loop no longer occuers, so the watcher process behaves as expected.

Fixes  #94 & #85.