### PR TITLE
fix: print messages from hooks only with `--log trace`

### DIFF
--- a/src/lib/before-prepare.js
+++ b/src/lib/before-prepare.js
@@ -4,9 +4,9 @@ module.exports = function ($logger, $projectData, $usbLiveSyncService) {
 	var liveSync = $usbLiveSyncService.isInitialized;
 	var bundle = $projectData.$options.bundle;
 	if (liveSync || bundle) {
-		$logger.warn("Hook skipped because either bundling or livesync is in progress.")
+		$logger.trace("Hook skipped because either bundling or livesync is in progress.")
 		return;
 	}
-	
+
 	return converter.convert($logger, $projectData.projectDir, $projectData.appDirectoryPath, $projectData.appResourcesDirectoryPath);
 }

--- a/src/lib/compiler.js
+++ b/src/lib/compiler.js
@@ -15,12 +15,12 @@ function compile(data) {
 	return new Promise((res, rej) => {
 		var projectDir = data.projectDir,
 			appDir = data.appDir;
-		
+
 		var logger = new LogProvider(data.logger);
 
 		var sassPath = require.resolve('node-sass/bin/node-sass');
 		if (fs.existsSync(sassPath)) {
-			logger.info("Found peer node-sass");
+			logger.trace("Found peer node-sass");
 		} else {
 			isResolved = true;
 			rej(new Error('node-sass installation local to project was not found. Install by executing `npm install node-sass`.'));

--- a/src/lib/watch.js
+++ b/src/lib/watch.js
@@ -4,7 +4,7 @@ module.exports = function (logger, projectData, usbLiveSyncService, hookArgs) {
 	if (hookArgs.config) {
 		const appFilesUpdaterOptions = hookArgs.config.appFilesUpdaterOptions;
 		if (appFilesUpdaterOptions.bundle) {
-			logger.warn("Hook skipped because bundling is in progress.")
+			logger.trace("Hook skipped because bundling is in progress.")
 			return;
 		}
 	}


### PR DESCRIPTION
Currently several messages from hooks are printed as warnings or information messages. They do not have any information for the users, so move them to the trace output.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

releated to https://github.com/NativeScript/nativescript-dev-sass/issues/102 